### PR TITLE
fix: use matching versions instead of explicit workspace versions

### DIFF
--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -18,8 +18,8 @@
     "author": "vivianjeng <vivi432@yahoo.com.tw>",
     "license": "MIT",
     "dependencies": {
-        "@unirep/config": "workspace:*",
-        "@unirep/crypto": "workspace:*",
+        "@unirep/config": "1.0.0",
+        "@unirep/crypto": "1.0.0",
         "argparse": "^2.0.1",
         "circom": "0.5.45",
         "circomlib": "0.5.3",

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -1,8 +1,10 @@
 {
     "name": "@unirep/circuits",
     "version": "1.0.4",
-    "main": "dist/circuits/utils.js",
+    "main": "circuits/utils.js",
+    "types": "circuits/utils.d.ts",
     "scripts": {
+        "pre": "sh scripts/pre.sh",
         "build": "yarn downloadPtau && yarn buildCircuits && yarn buildVerifyEpochKeySnark && yarn buildUserStateTransitionSnark && yarn buildProveReputationSnark && yarn buildProveUserSignUpSnark && tsc && yarn copyCircom",
         "downloadPtau": "./scripts/downloadPtau.sh",
         "buildCircuits": "npx ts-node scripts/buildCircuits.ts",
@@ -14,12 +16,12 @@
         "test": "mocha -r ts-node/register test/*.test.ts --exit",
         "lint": "prettier --write ."
     },
-    "repository": "https://github.com/Unirep/circuits.git",
+    "repository": "https://github.com/unirep/unirep.git",
     "author": "vivianjeng <vivi432@yahoo.com.tw>",
     "license": "MIT",
     "dependencies": {
-        "@unirep/config": "1.0.0",
-        "@unirep/crypto": "1.0.0",
+        "@unirep/config": "1.0.0-alpha-1",
+        "@unirep/crypto": "1.0.0-alpha-1",
         "argparse": "^2.0.1",
         "circom": "0.5.45",
         "circomlib": "0.5.3",

--- a/packages/circuits/scripts/pre.sh
+++ b/packages/circuits/scripts/pre.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp package.json dist
+cp README.md dist
+rm dist/zksnarkBuild/powersOfTau28_hez_final_17.ptau

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,3 @@
+# Unirep Config
+
+Default circuit/contract configuration for Unirep.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@unirep/config",
-    "private": false,
     "version": "1.0.0",
     "description": "Default unirep config",
     "main": "index.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,13 +1,17 @@
 {
     "name": "@unirep/config",
+    "private": false,
     "version": "1.0.0",
-    "description": "Default unirep config ",
-    "main": "build/index.js",
+    "description": "Default unirep config",
+    "main": "index.js",
+    "types": "index.d.ts",
     "repository": "https://github.com/Unirep/Unirep",
     "author": "Unirep Team",
     "license": "MIT",
     "scripts": {
-        "build": "yarn tsc",
+        "clean": "rm -rf build",
+        "pre": "sh scripts/prepare.sh",
+        "build": "tsc",
         "test": "echo 'No test!!!'"
     },
     "devDependencies": {

--- a/packages/config/scripts/prepare.sh
+++ b/packages/config/scripts/prepare.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp package.json build
+cp .gitignore build
+cp README.md build

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,10 +1,12 @@
 {
     "name": "@unirep/contracts",
     "version": "1.0.6",
-    "main": "build/src/index.js",
+    "main": "src/index.js",
+    "types": "src/index.d.ts",
     "author": "vivianjeng <vivi432@yahoo.com.tw>",
     "license": "MIT",
     "scripts": {
+        "pre": "sh scripts/pre.sh",
         "build": "./scripts/buildVerifiers.sh && yarn compile && npx hardhat typechain && tsc",
         "compile": "npx hardhat compile",
         "test": "npx hardhat test --no-compile",
@@ -14,9 +16,9 @@
         "@openzeppelin/contracts": "4.4.2",
         "@typechain/ethers-v5": "^9.0.0",
         "@typechain/hardhat": "^5.0.0",
-        "@unirep/circuits": "1.0.4",
-        "@unirep/config": "1.0.0",
-        "@unirep/crypto": "1.0.0",
+        "@unirep/circuits": "1.0.4-alpha-1",
+        "@unirep/config": "1.0.0-alpha-1",
+        "@unirep/crypto": "1.0.0-alpha-1",
         "argparse": "^2.0.1",
         "ethers": "^5.5.3",
         "typescript": "^4.4.3"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,9 +14,9 @@
         "@openzeppelin/contracts": "4.4.2",
         "@typechain/ethers-v5": "^9.0.0",
         "@typechain/hardhat": "^5.0.0",
-        "@unirep/circuits": "workspace:*",
-        "@unirep/config": "workspace:*",
-        "@unirep/crypto": "workspace:*",
+        "@unirep/circuits": "1.0.4",
+        "@unirep/config": "1.0.0",
+        "@unirep/crypto": "1.0.0",
         "argparse": "^2.0.1",
         "ethers": "^5.5.3",
         "typescript": "^4.4.3"

--- a/packages/contracts/scripts/pre.sh
+++ b/packages/contracts/scripts/pre.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp package.json build
+cp README.md build

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,8 +2,10 @@
     "name": "@unirep/core",
     "version": "1.0.0",
     "description": "",
-    "main": "build/src/index.js",
+    "main": "src/index.js",
+    "types": "src/index.d.ts",
     "scripts": {
+        "pre": "sh scripts/pre.sh",
         "build": "tsc",
         "test-cli": "./scripts/testCLI.sh",
         "test": "yarn UnirepStateTests & yarn UserStateTests & yarn integrationTest",
@@ -12,13 +14,13 @@
         "UserStateTests": "NODE_OPTIONS=--max-old-space-size=4096 npx hardhat test --parallel --no-compile $(find test/UserState -name '*.test.ts')",
         "lint": "prettier --write ."
     },
-    "repository": "git+https://github.com/appliedzkp/UniRep.git",
+    "repository": "https://github.com/unirep/unirep",
     "author": "",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/appliedzkp/UniRep/issues"
+        "url": "https://github.com/unirep/unirep/issues"
     },
-    "homepage": "https://github.com/appliedzkp/UniRep#readme",
+    "homepage": "https://github.com/unirep/unirep#readme",
     "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
@@ -35,9 +37,9 @@
     },
     "dependencies": {
         "@typechain/ethers-v5": "^9.0.0",
-        "@unirep/circuits": "1.0.4",
-        "@unirep/contracts": "1.0.6",
-        "@unirep/crypto": "1.0.0",
+        "@unirep/circuits": "1.0.4-alpha-1",
+        "@unirep/contracts": "1.0.6-alpha-1",
+        "@unirep/crypto": "1.0.0-alpha-1",
         "argparse": "^2.0.1",
         "base64url": "^3.0.1",
         "ethers": "^5.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,9 +35,9 @@
     },
     "dependencies": {
         "@typechain/ethers-v5": "^9.0.0",
-        "@unirep/circuits": "workspace:*",
-        "@unirep/contracts": "workspace:*",
-        "@unirep/crypto": "workspace:*",
+        "@unirep/circuits": "1.0.4",
+        "@unirep/contracts": "1.0.6",
+        "@unirep/crypto": "1.0.0",
         "argparse": "^2.0.1",
         "base64url": "^3.0.1",
         "ethers": "^5.4.6",

--- a/packages/core/scripts/pre.sh
+++ b/packages/core/scripts/pre.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp package.json build
+cp README.md build

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -2,12 +2,14 @@
     "name": "@unirep/crypto",
     "version": "1.0.0",
     "main": "build/index.js",
+    "types": "index.d.ts",
     "scripts": {
+        "pre": "sh scripts/prepare.sh",
         "build": "tsc",
         "test": "echo 'No test for crypto!!!'",
         "lint": "prettier --write ."
     },
-    "repository": "https://github.com/Unirep/crypto.git",
+    "repository": "https://github.com/unirep/unirep.git",
     "author": "vivianjeng <vivi432@yahoo.com.tw>",
     "license": "MIT",
     "dependencies": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@unirep/crypto",
     "version": "1.0.0",
-    "main": "build/index.js",
+    "main": "index.js",
     "types": "index.d.ts",
     "scripts": {
         "pre": "sh scripts/prepare.sh",

--- a/packages/crypto/scripts/prepare.sh
+++ b/packages/crypto/scripts/prepare.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp package.json build
+cp README.md build

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,15 +1388,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unirep/circuits@workspace:*, @unirep/circuits@workspace:packages/circuits":
+"@unirep/circuits@1.0.4, @unirep/circuits@workspace:packages/circuits":
   version: 0.0.0-use.local
   resolution: "@unirep/circuits@workspace:packages/circuits"
   dependencies:
     "@types/chai": ^4.2.21
     "@types/mocha": ^9.0.0
     "@types/node": ^16.9.1
-    "@unirep/config": "workspace:*"
-    "@unirep/crypto": "workspace:*"
+    "@unirep/config": 1.0.0
+    "@unirep/crypto": 1.0.0
     argparse: ^2.0.1
     chai: ^4.3.4
     circom: 0.5.45
@@ -1409,7 +1409,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/config@workspace:*, @unirep/config@workspace:packages/config":
+"@unirep/config@1.0.0, @unirep/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@unirep/config@workspace:packages/config"
   dependencies:
@@ -1417,7 +1417,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/contracts@workspace:*, @unirep/contracts@workspace:packages/contracts":
+"@unirep/contracts@1.0.6, @unirep/contracts@workspace:packages/contracts":
   version: 0.0.0-use.local
   resolution: "@unirep/contracts@workspace:packages/contracts"
   dependencies:
@@ -1429,9 +1429,9 @@ __metadata:
     "@types/chai": ^4.2.21
     "@types/mocha": ^9.0.0
     "@types/node": ^16.9.1
-    "@unirep/circuits": "workspace:*"
-    "@unirep/config": "workspace:*"
-    "@unirep/crypto": "workspace:*"
+    "@unirep/circuits": 1.0.4
+    "@unirep/config": 1.0.0
+    "@unirep/crypto": 1.0.0
     argparse: ^2.0.1
     chai: ^4.3.4
     circom: 0.5.45
@@ -1455,9 +1455,9 @@ __metadata:
     "@types/chai": ^4.3.0
     "@types/mocha": ^9.1.0
     "@types/node": ^17.0.10
-    "@unirep/circuits": "workspace:*"
-    "@unirep/contracts": "workspace:*"
-    "@unirep/crypto": "workspace:*"
+    "@unirep/circuits": 1.0.4
+    "@unirep/contracts": 1.0.6
+    "@unirep/crypto": 1.0.0
     argparse: ^2.0.1
     base64url: ^3.0.1
     bigint-conversion: ^2.1.12
@@ -1472,7 +1472,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/crypto@workspace:*, @unirep/crypto@workspace:packages/crypto":
+"@unirep/crypto@1.0.0, @unirep/crypto@workspace:packages/crypto":
   version: 0.0.0-use.local
   resolution: "@unirep/crypto@workspace:packages/crypto"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,15 +1388,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unirep/circuits@1.0.4, @unirep/circuits@workspace:packages/circuits":
+"@unirep/circuits@npm:1.0.4-alpha-1":
+  version: 1.0.4-alpha-1
+  resolution: "@unirep/circuits@npm:1.0.4-alpha-1"
+  dependencies:
+    "@unirep/config": 1.0.0-alpha-1
+    "@unirep/crypto": 1.0.0-alpha-1
+    argparse: ^2.0.1
+    circom: 0.5.45
+    circomlib: 0.5.3
+    snarkjs: ^0.4.7
+    typescript: ^4.4.2
+  checksum: b0def3dae24a41cd2f89823cd6fcee5300d5494629da98e68e82c8a3caf6fd00d18524e6d934f046b9b535724420683cfb405aed37bc523eb07fffbde9805192
+  languageName: node
+  linkType: hard
+
+"@unirep/circuits@workspace:packages/circuits":
   version: 0.0.0-use.local
   resolution: "@unirep/circuits@workspace:packages/circuits"
   dependencies:
     "@types/chai": ^4.2.21
     "@types/mocha": ^9.0.0
     "@types/node": ^16.9.1
-    "@unirep/config": 1.0.0
-    "@unirep/crypto": 1.0.0
+    "@unirep/config": 1.0.0-alpha-1
+    "@unirep/crypto": 1.0.0-alpha-1
     argparse: ^2.0.1
     chai: ^4.3.4
     circom: 0.5.45
@@ -1409,7 +1424,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/config@1.0.0, @unirep/config@workspace:packages/config":
+"@unirep/config@npm:1.0.0-alpha-1":
+  version: 1.0.0-alpha-1
+  resolution: "@unirep/config@npm:1.0.0-alpha-1"
+  checksum: bb2618571d64008a000e7e87dc11ce9f9e36c79bf475690b4bddf92958e3b27468f95f876f8073e3734efcf5143690787fdda1e4edc0db12351ea3f85726ed5e
+  languageName: node
+  linkType: hard
+
+"@unirep/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@unirep/config@workspace:packages/config"
   dependencies:
@@ -1417,7 +1439,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/contracts@1.0.6, @unirep/contracts@workspace:packages/contracts":
+"@unirep/contracts@npm:1.0.6-alpha-1":
+  version: 1.0.6-alpha-1
+  resolution: "@unirep/contracts@npm:1.0.6-alpha-1"
+  dependencies:
+    "@openzeppelin/contracts": 4.4.2
+    "@typechain/ethers-v5": ^9.0.0
+    "@typechain/hardhat": ^5.0.0
+    "@unirep/circuits": 1.0.4-alpha-1
+    "@unirep/config": 1.0.0-alpha-1
+    "@unirep/crypto": 1.0.0-alpha-1
+    argparse: ^2.0.1
+    ethers: ^5.5.3
+    typescript: ^4.4.3
+  checksum: 285351b6e82ebe85e22b8e75d0b42c0f003f58c000bed3e01e8a27c2c951ddd8b2f97446d00c81d131d87e2b91021aa325b48ae3e033bdf90b86c46627eb1fb3
+  languageName: node
+  linkType: hard
+
+"@unirep/contracts@workspace:packages/contracts":
   version: 0.0.0-use.local
   resolution: "@unirep/contracts@workspace:packages/contracts"
   dependencies:
@@ -1429,9 +1468,9 @@ __metadata:
     "@types/chai": ^4.2.21
     "@types/mocha": ^9.0.0
     "@types/node": ^16.9.1
-    "@unirep/circuits": 1.0.4
-    "@unirep/config": 1.0.0
-    "@unirep/crypto": 1.0.0
+    "@unirep/circuits": 1.0.4-alpha-1
+    "@unirep/config": 1.0.0-alpha-1
+    "@unirep/crypto": 1.0.0-alpha-1
     argparse: ^2.0.1
     chai: ^4.3.4
     circom: 0.5.45
@@ -1455,9 +1494,9 @@ __metadata:
     "@types/chai": ^4.3.0
     "@types/mocha": ^9.1.0
     "@types/node": ^17.0.10
-    "@unirep/circuits": 1.0.4
-    "@unirep/contracts": 1.0.6
-    "@unirep/crypto": 1.0.0
+    "@unirep/circuits": 1.0.4-alpha-1
+    "@unirep/contracts": 1.0.6-alpha-1
+    "@unirep/crypto": 1.0.0-alpha-1
     argparse: ^2.0.1
     base64url: ^3.0.1
     bigint-conversion: ^2.1.12
@@ -1472,7 +1511,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@unirep/crypto@1.0.0, @unirep/crypto@workspace:packages/crypto":
+"@unirep/crypto@npm:1.0.0-alpha-1":
+  version: 1.0.0-alpha-1
+  resolution: "@unirep/crypto@npm:1.0.0-alpha-1"
+  dependencies:
+    "@zk-kit/incremental-merkle-tree": ^0.4.3
+    bigint-conversion: ^2.1.12
+    circomlibjs: 0.0.8
+    crypto-js: ^4.1.1
+    maci-config: ^0.9.1
+    maci-crypto: ^0.9.1
+    typescript: ^4.4.2
+  checksum: 8996b8969a2b2eb971ce6d0dfaf707f55ec1414bb8a8962536dab13f5ca4f27145209c842deb228bf457a402f72ca32ff0b02eb2b7a8601911ae4535f9a0ad54
+  languageName: node
+  linkType: hard
+
+"@unirep/crypto@workspace:packages/crypto":
   version: 0.0.0-use.local
   resolution: "@unirep/crypto@workspace:packages/crypto"
   dependencies:


### PR DESCRIPTION
We need to publish the packages to npm before we can use the monorepo url as a git dependency. [Yarn workspaces will automatically link packages if the specific version is the same as the version in the local package](https://yarnpkg.com/features/workspaces#what-does-it-mean-to-be-a-workspace). This means any external package using the git repo as a package dep will get a version number for other packages in the monorepo.

We need to publish versions of each package to npm so that module resolution won't fail when e.g. `contracts` depends on `crypto`.