### PR TITLE
fix(contracts): increase runs value to max

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -23,7 +23,7 @@ const config: HardhatUserConfig = {
             {
                 version: '0.8.17',
                 settings: {
-                    optimizer: { enabled: true, runs: 200 },
+                    optimizer: { enabled: true, runs: 2 ** 32 - 1 },
                 },
             },
         ],

--- a/packages/core/hardhat.config.ts
+++ b/packages/core/hardhat.config.ts
@@ -18,7 +18,7 @@ const config: HardhatUserConfig = {
             {
                 version: '0.8.17',
                 settings: {
-                    optimizer: { enabled: true, runs: 200 },
+                    optimizer: { enabled: true, runs: 2 ** 32 - 1 },
                 },
             },
         ],


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint --check`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?


## What is the new behavior?

The `runs` value in the solidity optimizer is designed to optimize between deploy cost and call cost. Low `runs` value optimizes for a low deployment cost, high runs value optimizes for call costs. `runs` is the number of times the contract can be expected to be called. [More info here](https://docs.soliditylang.org/en/latest/internals/optimizer.html#optimizer-parameter-runs)

In the case of unirep we're deploying a global contract that many applications/users will interact with over time. As a result we should optimize for call cost as much as possible because the deploy cost is a (more or less) one time expenditure.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
