### PR TITLE
445 synchronization

### DIFF
--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -25,7 +25,6 @@ class BlockQueue {
     private promises: any[] = []
     public arr: any[] = []
     public blockEnd: Number = 0
-    private chunkToGo: number = 0
     insert(block: Promise<any>, idx: number) {
         block.then((r) => {
             this.promises.push({ idx, r })
@@ -40,11 +39,6 @@ class BlockQueue {
             if (chunk.r === undefined || chunk.r.length === 0) {
                 continue
             }
-            if (chunk.idx != this.chunkToGo) {
-                tmp.push(chunk)
-                continue
-            }
-            this.chunkToGo += 1
             for (const block of chunk.r) {
                 this.arr.splice(0, 0, block)
             }
@@ -53,7 +47,6 @@ class BlockQueue {
     }
     clear() {
         this.arr = []
-        this.chunkToGo = 0
         if (this.promises.length > 0) {
             const firstIdx = this.promises[0].idx
             this.promises.forEach((x) => x - firstIdx)

--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -35,7 +35,7 @@ class BlockQueue {
         this.promises.sort((a, b) => {
             return a.idx - b.idx
         })
-        const tmp = []
+        const tmp: any[] = []
         for (const chunk of this.promises) {
             if (chunk.r === undefined || chunk.r.length === 0) {
                 continue

--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -45,7 +45,7 @@ export class Synchronizer extends EventEmitter {
 
     private pollId: string | null = null
     public pollRate: number = 5000
-    public blockRate: number = 20
+    public blockRate: number = 10000
 
     private setupComplete = false
     private setupPromise


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally in root directory and any changes were pushed
- [x] Lint (`yarn lint:fix`) was run locally in root directory and any changes were pushed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Currently, the synchronizer serially loads `blockRate` blocks and processes them in each loop. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  Closes #445 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Blocks are loaded in parallel and separately processed
- Each parallel request uses exponential backoff logic
- `chunks` (Segments of blocks like blocks 1-20) are processed in order

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Currently, chunks are contiguous sets of 20 blocks
