### PR TITLE
Update circuits to semaphore v4

### DIFF
--- a/packages/circuits/circuits/identity.circom
+++ b/packages/circuits/circuits/identity.circom
@@ -3,22 +3,20 @@ pragma circom 2.1.0;
 include "./circomlib/circuits/poseidon.circom";
 
 template IdentitySecret() {
-  signal input nullifier;
-  signal input trapdoor;
+  signal input secret;
 
   signal output out;
 
-  out <== Poseidon(2)([nullifier, trapdoor]);
+  out <== Poseidon(1)([secret]);
 }
 
 template IdentityCommitment() {
-  signal input nullifier;
-  signal input trapdoor;
+  signal input secret;
 
-  signal output secret;
-  signal output out;
+  signal output identity_secret;
+  signal output identity_commitment;
 
-  secret <== IdentitySecret()(nullifier, trapdoor);
-  out <== Poseidon(1)([secret]);
+  identity_secret <== IdentitySecret()(secret);
+  identity_commitment <== Poseidon(1)([identity_secret]);
 }
 

--- a/packages/circuits/circuits/identity.circom
+++ b/packages/circuits/circuits/identity.circom
@@ -2,21 +2,11 @@ pragma circom 2.1.0;
 
 include "./circomlib/circuits/poseidon.circom";
 
-template IdentitySecret() {
-  signal input secret;
-
-  signal output out;
-
-  out <== Poseidon(1)([secret]);
-}
-
 template IdentityCommitment() {
   signal input secret;
 
-  signal output identity_secret;
   signal output identity_commitment;
 
-  identity_secret <== IdentitySecret()(secret);
-  identity_commitment <== Poseidon(1)([identity_secret]);
+  identity_commitment <== Poseidon(1)([secret]);
 }
 

--- a/packages/circuits/circuits/identity.circom
+++ b/packages/circuits/circuits/identity.circom
@@ -5,8 +5,8 @@ include "./circomlib/circuits/poseidon.circom";
 template IdentityCommitment() {
   signal input secret;
 
-  signal output identity_commitment;
+  signal output commitment;
 
-  identity_commitment <== Poseidon(1)([secret]);
+  commitment <== Poseidon(1)([secret]);
 }
 

--- a/packages/circuits/circuits/preventDoubleAction.circom
+++ b/packages/circuits/circuits/preventDoubleAction.circom
@@ -24,20 +24,18 @@ template PreventDoubleAction(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_
     // Optionally reveal nonce, epoch, attester_id
     signal output control;
 
-    signal input identity_nullifier;
+    signal input secret;
     signal input external_nullifier;
     signal output nullifier;
-
-    signal input identity_trapdoor;
 
     signal input data[FIELD_COUNT];
 
     /* 1. Compute nullifier */
-    nullifier <== Poseidon(2)([identity_nullifier, external_nullifier]);
+    nullifier <== Poseidon(2)([secret, external_nullifier]);
 
      /* 2. Compute identity commitment */
     signal identity_secret;
-    (identity_secret, _) <== IdentityCommitment()(identity_nullifier, identity_trapdoor);
+    (identity_secret, _) <== IdentityCommitment()(secret);
 
     /* 3. Check epoch key is valid */
     (epoch_key, state_tree_root, control) <== EpochKey(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_COUNT)(

--- a/packages/circuits/circuits/preventDoubleAction.circom
+++ b/packages/circuits/circuits/preventDoubleAction.circom
@@ -34,8 +34,8 @@ template PreventDoubleAction(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_
     nullifier <== Poseidon(2)([secret, external_nullifier]);
 
      /* 2. Compute identity commitment */
-    signal identity_commitment;
-    identity_commitment <== IdentityCommitment()(secret);
+    signal commitment;
+    commitment <== IdentityCommitment()(secret);
 
     /* 3. Check epoch key is valid */
     (epoch_key, state_tree_root, control) <== EpochKey(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_COUNT)(

--- a/packages/circuits/circuits/preventDoubleAction.circom
+++ b/packages/circuits/circuits/preventDoubleAction.circom
@@ -34,14 +34,14 @@ template PreventDoubleAction(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_
     nullifier <== Poseidon(2)([secret, external_nullifier]);
 
      /* 2. Compute identity commitment */
-    signal identity_secret;
-    (identity_secret, _) <== IdentityCommitment()(secret);
+    signal identity_commitment;
+    identity_commitment <== IdentityCommitment()(secret);
 
     /* 3. Check epoch key is valid */
     (epoch_key, state_tree_root, control) <== EpochKey(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_COUNT)(
         state_tree_indexes,
         state_tree_elements,
-        identity_secret,
+        secret,
         reveal_nonce,
         attester_id,
         epoch,

--- a/packages/circuits/circuits/signup.circom
+++ b/packages/circuits/circuits/signup.circom
@@ -17,9 +17,7 @@ template Signup(FIELD_COUNT) {
 
     signal input secret;
 
-    signal identity_secret;
-
-    (identity_secret, identity_commitment) <== IdentityCommitment()(secret);
+    identity_commitment <== IdentityCommitment()(secret);
  
     _ <== Num2Bits(48)(epoch);
     _ <== Num2Bits(160)(attester_id);
@@ -30,8 +28,7 @@ template Signup(FIELD_COUNT) {
     }
     (state_tree_leaf, control, _) <== StateTreeLeaf(FIELD_COUNT)(
       data,
-      identity_secret, 
+      secret, 
       attester_id, 
       epoch);
 }
-

--- a/packages/circuits/circuits/signup.circom
+++ b/packages/circuits/circuits/signup.circom
@@ -8,7 +8,7 @@ include "./hasher.circom";
 
 template Signup(FIELD_COUNT) {
 
-    signal output identity_commitment;
+    signal output commitment;
     signal output state_tree_leaf;
     signal output control;
 
@@ -17,7 +17,7 @@ template Signup(FIELD_COUNT) {
 
     signal input secret;
 
-    identity_commitment <== IdentityCommitment()(secret);
+    commitment <== IdentityCommitment()(secret);
  
     _ <== Num2Bits(48)(epoch);
     _ <== Num2Bits(160)(attester_id);

--- a/packages/circuits/circuits/signup.circom
+++ b/packages/circuits/circuits/signup.circom
@@ -15,14 +15,11 @@ template Signup(FIELD_COUNT) {
     signal input attester_id;
     signal input epoch;
 
-    signal input identity_nullifier;
-    signal input identity_trapdoor;
+    signal input secret;
 
     signal identity_secret;
 
-    (identity_secret, identity_commitment) <== IdentityCommitment()(
-      identity_nullifier,
-      identity_trapdoor);
+    (identity_secret, identity_commitment) <== IdentityCommitment()(secret);
  
     _ <== Num2Bits(48)(epoch);
     _ <== Num2Bits(160)(attester_id);

--- a/packages/circuits/test/preventDoubleAction.test.ts
+++ b/packages/circuits/test/preventDoubleAction.test.ts
@@ -18,6 +18,7 @@ import {
     genProofAndVerify,
     randomData,
     genPreventDoubleActionCircuitInput,
+    genV4Identity,
 } from './utils'
 
 const { STATE_TREE_DEPTH, NUM_EPOCH_KEY_NONCE_PER_EPOCH } =
@@ -32,8 +33,9 @@ describe('Prevent double action circuit', function () {
             const epoch = 120958
             const data = randomData()
             const id = new Identity()
+            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -52,7 +54,7 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
             expect(publicSignals[2]).to.equal(
@@ -62,7 +64,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([id.nullifier, externalNullifier])
+            const nullifier = poseidon2([newId.nullifier, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
 
             const p = new PreventDoubleActionProof(publicSignals, proof)
@@ -71,7 +73,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal('0')
@@ -93,8 +95,9 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const revealNonce = 1
             const id = new Identity()
+            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -114,10 +117,10 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([id.nullifier, externalNullifier])
+            const nullifier = poseidon2([newId.nullifier, externalNullifier])
             expect(publicSignals[2]).to.equal(
                 EpochKeyLiteProof.buildControl({
                     attesterId,
@@ -134,7 +137,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal(revealNonce.toString())
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal('0')
@@ -149,8 +152,9 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const sigData = BigInt(1288972090)
             const id = new Identity()
+            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -170,7 +174,7 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
             expect(publicSignals[2]).to.equal(
@@ -180,7 +184,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([id.nullifier, externalNullifier])
+            const nullifier = poseidon2([newId.nullifier, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -190,7 +194,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal(sigData.toString())
@@ -212,8 +216,9 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const sigData = BigInt(1288972090)
             const id = new Identity()
+            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -233,10 +238,10 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([id.nullifier, externalNullifier])
+            const nullifier = poseidon2([newId.nullifier, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -246,7 +251,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal(sigData.toString())
@@ -275,8 +280,9 @@ describe('Prevent double action circuit', function () {
         const data = randomData()
         const nonce = 0
         const id = new Identity()
+        const newId = genV4Identity(id)
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-        const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+        const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
         tree.insert(leaf)
         const externalNullifier = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -296,7 +302,7 @@ describe('Prevent double action circuit', function () {
         )
         expect(isValid).to.be.true
         expect(publicSignals[0]).to.equal(
-            genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+            genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
         )
         expect(publicSignals[1]).to.not.equal(tree.root.toString())
     })
@@ -307,8 +313,9 @@ describe('Prevent double action circuit', function () {
         const data = randomData()
         const nonce = 0
         const id = new Identity()
+        const newId = genV4Identity(id)
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-        const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
+        const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
         tree.insert(leaf)
         const externalNullifier = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -330,7 +337,7 @@ describe('Prevent double action circuit', function () {
         expect(isValid).to.be.true
 
         expect(publicSignals[0]).to.not.equal(
-            genEpochKey(id.secret, attesterId, epoch, nonce).toString()
+            genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
         )
         expect(publicSignals[1]).to.not.equal(tree.root.toString())
     })

--- a/packages/circuits/test/preventDoubleAction.test.ts
+++ b/packages/circuits/test/preventDoubleAction.test.ts
@@ -18,7 +18,6 @@ import {
     genProofAndVerify,
     randomData,
     genPreventDoubleActionCircuitInput,
-    genV4Identity,
 } from './utils'
 
 const { STATE_TREE_DEPTH, NUM_EPOCH_KEY_NONCE_PER_EPOCH } =
@@ -33,9 +32,8 @@ describe('Prevent double action circuit', function () {
             const epoch = 120958
             const data = randomData()
             const id = new Identity()
-            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -54,7 +52,7 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
             expect(publicSignals[2]).to.equal(
@@ -64,7 +62,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([newId.nullifier, externalNullifier])
+            const nullifier = poseidon2([id.secret, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
 
             const p = new PreventDoubleActionProof(publicSignals, proof)
@@ -73,7 +71,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal('0')
@@ -95,9 +93,8 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const revealNonce = 1
             const id = new Identity()
-            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -117,10 +114,10 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([newId.nullifier, externalNullifier])
+            const nullifier = poseidon2([id.secret, externalNullifier])
             expect(publicSignals[2]).to.equal(
                 EpochKeyLiteProof.buildControl({
                     attesterId,
@@ -137,7 +134,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal(revealNonce.toString())
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal('0')
@@ -152,9 +149,8 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const sigData = BigInt(1288972090)
             const id = new Identity()
-            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -174,7 +170,7 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
             expect(publicSignals[2]).to.equal(
@@ -184,7 +180,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([newId.nullifier, externalNullifier])
+            const nullifier = poseidon2([id.secret, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -194,7 +190,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal(sigData.toString())
@@ -216,9 +212,8 @@ describe('Prevent double action circuit', function () {
             const data = randomData()
             const sigData = BigInt(1288972090)
             const id = new Identity()
-            const newId = genV4Identity(id)
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-            const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+            const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
             const externalNullifier = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -238,10 +233,10 @@ describe('Prevent double action circuit', function () {
             )
             expect(isValid).to.be.true
             expect(publicSignals[0]).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([newId.nullifier, externalNullifier])
+            const nullifier = poseidon2([id.secret, externalNullifier])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -251,7 +246,7 @@ describe('Prevent double action circuit', function () {
             expect(p.revealNonce.toString()).to.equal('0')
             expect(p.attesterId.toString()).to.equal(attesterId.toString())
             expect(p.epochKey.toString()).to.equal(
-                genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+                genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(p.stateTreeRoot.toString()).to.equal(tree.root.toString())
             expect(p.sigData.toString()).to.equal(sigData.toString())
@@ -280,9 +275,8 @@ describe('Prevent double action circuit', function () {
         const data = randomData()
         const nonce = 0
         const id = new Identity()
-        const newId = genV4Identity(id)
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-        const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+        const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
         tree.insert(leaf)
         const externalNullifier = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -302,7 +296,7 @@ describe('Prevent double action circuit', function () {
         )
         expect(isValid).to.be.true
         expect(publicSignals[0]).to.equal(
-            genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+            genEpochKey(id.secret, attesterId, epoch, nonce).toString()
         )
         expect(publicSignals[1]).to.not.equal(tree.root.toString())
     })
@@ -313,9 +307,8 @@ describe('Prevent double action circuit', function () {
         const data = randomData()
         const nonce = 0
         const id = new Identity()
-        const newId = genV4Identity(id)
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
-        const leaf = genStateTreeLeaf(newId.secret, attesterId, epoch, data)
+        const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
         tree.insert(leaf)
         const externalNullifier = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
@@ -337,7 +330,7 @@ describe('Prevent double action circuit', function () {
         expect(isValid).to.be.true
 
         expect(publicSignals[0]).to.not.equal(
-            genEpochKey(newId.secret, attesterId, epoch, nonce).toString()
+            genEpochKey(id.secret, attesterId, epoch, nonce).toString()
         )
         expect(publicSignals[1]).to.not.equal(tree.root.toString())
     })

--- a/packages/circuits/test/provers.test.ts
+++ b/packages/circuits/test/provers.test.ts
@@ -32,8 +32,7 @@ for (const { name, prover } of provers) {
                 await prover.genProofAndPublicSignals('signup', {
                     attester_id: 0,
                     epoch: 0,
-                    identity_nullifier: 0,
-                    identity_trapdoor: 0,
+                    secret: 0,
                 })
             expect(publicSignals).to.exist
             expect(Array.isArray(publicSignals)).to.be.true
@@ -47,8 +46,7 @@ for (const { name, prover } of provers) {
                 await prover.genProofAndPublicSignals('signup', {
                     attester_id: 0,
                     epoch: 0,
-                    identity_nullifier: 0,
-                    identity_trapdoor: 0,
+                    secret: 0,
                 })
             const valid = await prover.verifyProof(
                 'signup',

--- a/packages/circuits/test/utils.ts
+++ b/packages/circuits/test/utils.ts
@@ -37,19 +37,6 @@ export const combineData = (data0, data1) => {
     return out
 }
 
-const genV4Identity = (id: Identity) => {
-    const nullifier = id.nullifier
-    const secret = poseidon1([id.nullifier])
-    const commitment = poseidon1([poseidon1([id.nullifier])])
-    const newId = {
-        nullifier,
-        secret,
-        commitment,
-    }
-
-    return newId
-}
-
 const genEpochKeyCircuitInput = (config: {
     id: Identity
     tree: utils.IncrementalMerkleTree
@@ -241,7 +228,7 @@ const genPreventDoubleActionCircuitInput = (config: {
         epoch,
         attester_id: attesterId,
         reveal_nonce: revealNonce ?? 0,
-        secret: id.nullifier,
+        secret: id.secret,
         external_nullifier: externalNullifier,
     }
 
@@ -254,5 +241,4 @@ export {
     genReputationCircuitInput,
     genProofAndVerify,
     genPreventDoubleActionCircuitInput,
-    genV4Identity,
 }

--- a/packages/circuits/test/utils.ts
+++ b/packages/circuits/test/utils.ts
@@ -180,8 +180,7 @@ const genSignupCircuitInput = (config: {
 }) => {
     const { id, epoch, attesterId } = Object.assign(config)
     const circuitInputs = {
-        identity_nullifier: id.nullifier,
-        identity_trapdoor: id.trapdoor,
+        secret: id.secret,
         epoch,
         attester_id: attesterId,
     }

--- a/packages/circuits/test/utils.ts
+++ b/packages/circuits/test/utils.ts
@@ -37,6 +37,19 @@ export const combineData = (data0, data1) => {
     return out
 }
 
+const genV4Identity = (id: Identity) => {
+    const nullifier = id.nullifier
+    const secret = poseidon1([id.nullifier])
+    const commitment = poseidon1([poseidon1([id.nullifier])])
+    const newId = {
+        nullifier,
+        secret,
+        commitment,
+    }
+
+    return newId
+}
+
 const genEpochKeyCircuitInput = (config: {
     id: Identity
     tree: utils.IncrementalMerkleTree
@@ -228,9 +241,8 @@ const genPreventDoubleActionCircuitInput = (config: {
         epoch,
         attester_id: attesterId,
         reveal_nonce: revealNonce ?? 0,
-        identity_nullifier: id.nullifier,
+        secret: id.nullifier,
         external_nullifier: externalNullifier,
-        identity_trapdoor: id.trapdoor,
     }
 
     return utils.stringifyBigInts(circuitInputs)
@@ -242,4 +254,5 @@ export {
     genReputationCircuitInput,
     genProofAndVerify,
     genPreventDoubleActionCircuitInput,
+    genV4Identity,
 }

--- a/packages/contracts/test/accessors.test.ts
+++ b/packages/contracts/test/accessors.test.ts
@@ -52,8 +52,7 @@ describe('Attester getters', function () {
                 Circuit.signup,
                 stringifyBigInts({
                     epoch,
-                    identity_nullifier: id.nullifier,
-                    identity_trapdoor: id.trapdoor,
+                    secret: id.secret,
                     attester_id: attester.address,
                 })
             )

--- a/packages/contracts/test/userSignup.test.ts
+++ b/packages/contracts/test/userSignup.test.ts
@@ -51,8 +51,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: 0,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -81,8 +80,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: 0,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -113,8 +111,7 @@ describe('User Signup', function () {
                     Circuit.signup,
                     stringifyBigInts({
                         epoch,
-                        identity_nullifier: id.nullifier,
-                        identity_trapdoor: id.trapdoor,
+                        secret: id.secret,
                         attester_id: attester.address,
                     })
                 )
@@ -188,8 +185,7 @@ describe('User Signup', function () {
                 Circuit.signup,
                 stringifyBigInts({
                     epoch,
-                    identity_nullifier: id.nullifier,
-                    identity_trapdoor: id.trapdoor,
+                    secret: id.secret,
                     attester_id: attester.address,
                 })
             )
@@ -208,8 +204,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -235,8 +230,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: BigInt(unregisteredAttester.address),
             })
         )
@@ -261,8 +255,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: wrongEpoch,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -288,8 +281,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -316,8 +308,7 @@ describe('User Signup', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch,
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )

--- a/packages/contracts/test/userStateTransition.test.ts
+++ b/packages/contracts/test/userStateTransition.test.ts
@@ -34,8 +34,7 @@ const signupUser = async (id, unirepContract, attesterId, account) => {
         Circuit.signup,
         stringifyBigInts({
             epoch: epoch.toString(),
-            identity_nullifier: id.nullifier,
-            identity_trapdoor: id.trapdoor,
+            secret: id.secret,
             attester_id: attesterId,
         })
     )

--- a/packages/contracts/test/verifier.test.ts
+++ b/packages/contracts/test/verifier.test.ts
@@ -325,8 +325,7 @@ describe('Epoch key verifier helper', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: epoch.toString(),
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attesterId,
             })
         )
@@ -404,8 +403,7 @@ describe('Epoch key verifier helper', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: epoch.toString(),
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -652,8 +650,7 @@ describe('Reputation verifier helper', function () {
             Circuit.signup,
             stringifyBigInts({
                 epoch: epoch.toString(),
-                identity_nullifier: id.nullifier,
-                identity_trapdoor: id.trapdoor,
+                secret: id.secret,
                 attester_id: attester.address,
             })
         )
@@ -787,8 +784,7 @@ describe('Reputation verifier helper', function () {
                 Circuit.signup,
                 stringifyBigInts({
                     epoch: epoch.toString(),
-                    identity_nullifier: id.nullifier,
-                    identity_trapdoor: id.trapdoor,
+                    secret: id.secret,
                     attester_id: attester.address,
                 })
             )
@@ -851,8 +847,7 @@ describe('Reputation verifier helper', function () {
                 Circuit.signup,
                 stringifyBigInts({
                     epoch: epoch.toString(),
-                    identity_nullifier: id.nullifier,
-                    identity_trapdoor: id.trapdoor,
+                    secret: id.secret,
                     attester_id: attester.address,
                 })
             )

--- a/packages/core/src/UserState.ts
+++ b/packages/core/src/UserState.ts
@@ -606,8 +606,7 @@ export default class UserState {
         const epoch = options.epoch ?? this.sync.calcCurrentEpoch(attesterId)
         const circuitInputs = {
             epoch,
-            identity_nullifier: this.id.nullifier,
-            identity_trapdoor: this.id.trapdoor,
+            secret: this.id.secret,
             attester_id: attesterId,
         }
         const results = await this.prover.genProofAndPublicSignals(


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`yarn build`) was run locally in root directory and any changes were pushed
- [ ] Lint (`yarn lint:fix`) was run locally in root directory and any changes were pushed

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [X] Other (please describe): updating Semaphore Version

## What is the current behavior?

Issue Number: #541 

## What is the new behavior?
> The main changing is illustrated in the figure below

![image](https://github.com/Unirep/Unirep/assets/78428519/65ccb5a9-4b60-449d-a9b0-cd29e1aafadd)

- The original secret includes `trapdoor` and `nullifier`, now we change this into just `secret`.
- The way how we call `Semaphore/Identity` should be modified in the future. For now, we would use `Identity.secret` as the secret of identity, and the commitment would be `Identity.commitment`.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

This change might influence the way we use `Identity` and if there is anything about `trapdoor` and `nullifier`, should be modified in the future.

One thing is needed to point out: the semaphore version now still uses the old version of secrets : `identity_trapdoor` + `identity_nullifier`. Thus, the secret input I use for now is `identity_nullifier`, which means that
- identity secret = `hash ( identity_nullifier )`
- identity commitment = `hash ( hash ( identity_nullifier ) )`
- nullifier = `hash ([ identity_nullifier, external_nullifier ])`

However, this should be modified in the future after Semaphore v4 Identity's launch.

## Other information

❌

## TODO
- [X] update circuits to Semaphore v4 
- [X] modify circuit test `circuits/test/preventDoubleAction.test.ts`
- [ ] modify circuit test `circuits/test/signup.test.ts`
- [ ] modify configurations in `circuits/test/utils.ts`