### PR TITLE
Fix semaphore v4

### DIFF
--- a/packages/circuits/circuits/preventDoubleAction.circom
+++ b/packages/circuits/circuits/preventDoubleAction.circom
@@ -25,13 +25,13 @@ template PreventDoubleAction(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_
     signal output control;
 
     signal input secret;
-    signal input external_nullifier;
+    signal input scope;
     signal output nullifier;
 
     signal input data[FIELD_COUNT];
 
     /* 1. Compute nullifier */
-    nullifier <== Poseidon(2)([secret, external_nullifier]);
+    nullifier <== Poseidon(2)([scope, secret]);
 
      /* 2. Compute identity commitment */
     signal commitment;

--- a/packages/circuits/test/preventDoubleAction.test.ts
+++ b/packages/circuits/test/preventDoubleAction.test.ts
@@ -26,7 +26,7 @@ const { STATE_TREE_DEPTH, NUM_EPOCH_KEY_NONCE_PER_EPOCH } =
 describe('Prevent double action circuit', function () {
     this.timeout(300000)
 
-    it('should prove epoch key membership with external nullifier', async () => {
+    it('should prove epoch key membership with nullifier', async () => {
         for (let nonce = 0; nonce < NUM_EPOCH_KEY_NONCE_PER_EPOCH; nonce++) {
             const attesterId = BigInt(10210)
             const epoch = 120958
@@ -35,7 +35,7 @@ describe('Prevent double action circuit', function () {
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
-            const externalNullifier = BigInt(1)
+            const scope = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
                 id,
                 tree,
@@ -44,7 +44,7 @@ describe('Prevent double action circuit', function () {
                 nonce,
                 attesterId,
                 data,
-                externalNullifier,
+                scope,
             })
             const { isValid, publicSignals, proof } = await genProofAndVerify(
                 Circuit.preventDoubleAction,
@@ -62,7 +62,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([id.secret, externalNullifier])
+            const nullifier = poseidon2([scope, id.secret])
             expect(publicSignals[3]).to.equal(nullifier.toString())
 
             const p = new PreventDoubleActionProof(publicSignals, proof)
@@ -96,7 +96,7 @@ describe('Prevent double action circuit', function () {
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
-            const externalNullifier = BigInt(1)
+            const scope = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
                 id,
                 tree,
@@ -106,7 +106,7 @@ describe('Prevent double action circuit', function () {
                 attesterId,
                 data,
                 revealNonce,
-                externalNullifier,
+                scope,
             })
             const { isValid, publicSignals, proof } = await genProofAndVerify(
                 Circuit.preventDoubleAction,
@@ -117,7 +117,7 @@ describe('Prevent double action circuit', function () {
                 genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([id.secret, externalNullifier])
+            const nullifier = poseidon2([scope, id.secret])
             expect(publicSignals[2]).to.equal(
                 EpochKeyLiteProof.buildControl({
                     attesterId,
@@ -152,7 +152,7 @@ describe('Prevent double action circuit', function () {
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
-            const externalNullifier = BigInt(1)
+            const scope = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
                 id,
                 tree,
@@ -162,7 +162,7 @@ describe('Prevent double action circuit', function () {
                 attesterId,
                 sigData,
                 data,
-                externalNullifier,
+                scope,
             })
             const { isValid, publicSignals, proof } = await genProofAndVerify(
                 Circuit.preventDoubleAction,
@@ -180,7 +180,7 @@ describe('Prevent double action circuit', function () {
                     nonce,
                 }).toString()
             )
-            const nullifier = poseidon2([id.secret, externalNullifier])
+            const nullifier = poseidon2([scope, id.secret])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -215,7 +215,7 @@ describe('Prevent double action circuit', function () {
             const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
             const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
             tree.insert(leaf)
-            const externalNullifier = BigInt(1)
+            const scope = BigInt(1)
             const circuitInputs = genPreventDoubleActionCircuitInput({
                 id,
                 tree,
@@ -225,7 +225,7 @@ describe('Prevent double action circuit', function () {
                 attesterId,
                 data,
                 sigData,
-                externalNullifier,
+                scope,
             })
             const { isValid, publicSignals, proof } = await genProofAndVerify(
                 Circuit.preventDoubleAction,
@@ -236,7 +236,7 @@ describe('Prevent double action circuit', function () {
                 genEpochKey(id.secret, attesterId, epoch, nonce).toString()
             )
             expect(publicSignals[1]).to.equal(tree.root.toString())
-            const nullifier = poseidon2([id.secret, externalNullifier])
+            const nullifier = poseidon2([scope, id.secret])
             expect(publicSignals[3]).to.equal(nullifier.toString())
             expect(publicSignals[4].toString()).to.equal(sigData.toString())
 
@@ -278,7 +278,7 @@ describe('Prevent double action circuit', function () {
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
         const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
         tree.insert(leaf)
-        const externalNullifier = BigInt(1)
+        const scope = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
             id,
             tree,
@@ -287,7 +287,7 @@ describe('Prevent double action circuit', function () {
             nonce,
             attesterId,
             data,
-            externalNullifier,
+            scope,
         })
         circuitInputs.data[0] = 21908
         const { isValid, publicSignals } = await genProofAndVerify(
@@ -310,7 +310,7 @@ describe('Prevent double action circuit', function () {
         const tree = new IncrementalMerkleTree(STATE_TREE_DEPTH)
         const leaf = genStateTreeLeaf(id.secret, attesterId, epoch, data)
         tree.insert(leaf)
-        const externalNullifier = BigInt(1)
+        const scope = BigInt(1)
         const circuitInputs = genPreventDoubleActionCircuitInput({
             id,
             tree,
@@ -319,7 +319,7 @@ describe('Prevent double action circuit', function () {
             nonce,
             attesterId,
             data,
-            externalNullifier,
+            scope,
         })
 
         circuitInputs.attester_id = 2171828

--- a/packages/circuits/test/utils.ts
+++ b/packages/circuits/test/utils.ts
@@ -197,7 +197,7 @@ const genPreventDoubleActionCircuitInput = (config: {
     data?: bigint[]
     sigData?: bigint
     revealNonce?: number
-    externalNullifier: bigint
+    scope: bigint
 }) => {
     const {
         id,
@@ -209,7 +209,7 @@ const genPreventDoubleActionCircuitInput = (config: {
         data: _data,
         sigData,
         revealNonce,
-        externalNullifier,
+        scope,
     } = Object.assign(
         {
             data: [],
@@ -228,7 +228,7 @@ const genPreventDoubleActionCircuitInput = (config: {
         attester_id: attesterId,
         reveal_nonce: revealNonce ?? 0,
         secret: id.secret,
-        external_nullifier: externalNullifier,
+        scope: scope,
     }
 
     return utils.stringifyBigInts(circuitInputs)

--- a/packages/docs/docs/circuits-api/circuits.md
+++ b/packages/docs/docs/circuits-api/circuits.md
@@ -32,13 +32,19 @@ Control field:
 Inputs:
 - `attester_id`
 - `epoch`
-- `identity_nullifier`
-- `identity_trapdoor`
+- `secret`
 
 Outputs:
-- `identity_commitment`
+- `commitment`
 - `state_tree_leaf`
 - `control`
+
+Interface: 
+```js
+// pragma circom 2.1.0;
+// include "PATH/node_modules/@unirep/circuits/circuits/signup.circom"; 
+(commitment, state_tree_leaf, control) <== Signup(FIELD_COUNT)(attester_id, epoch, secret);
+```
 
 :::info
 Control fields are used to encode many small values into a single field element. This reduces the number of public signals needed to operate a circuit.
@@ -71,6 +77,23 @@ Outputs:
 - `epoch_key`
 - `state_tree_root`
 - `control`
+
+Interface: 
+```js
+// pragma circom 2.1.0;
+// include "PATH/node_modules/@unirep/circuits/circuits/epochKey.circom"; 
+(epoch_key, state_tree_root, control) <== EpochKey(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, FIELD_COUNT)(
+  state_tree_indexes, 
+  state_tree_elements, 
+  identity_secret,
+  reveal_nonce,
+  attester_id,
+  epoch,
+  nonce,
+  data,
+  sig_data
+);
+```
 
 :::info
 Control fields are used to encode many small values into a single field element. This reduces the number of public signals needed to operate a circuit.
@@ -105,6 +128,20 @@ Inputs:
 Outputs:
 - `epoch_key`
 - `control`
+
+Interface: 
+```js
+// pragma circom 2.1.0;
+// include "PATH/node_modules/@unirep/circuits/circuits/epochKeyLite.circom"; 
+(control, epoch_key) <== EpochKeyLite(EPOCH_KEY_NONCE_PER_EPOCH)(
+  identity_secret,
+  reveal_nonce,
+  attester_id,
+  epoch,
+  nonce,
+  sig_data
+);
+```
 
 :::info
 Control fields are used to encode many small values into a single field element. This reduces the number of public signals needed to operate a circuit.
@@ -158,6 +195,30 @@ Outputs:
 - `state_tree_root`
 - `control[2]`
 
+Interface: 
+```js
+// pragma circom 2.1.0;
+// include "PATH/node_modules/@unirep/circuits/circuits/proveReputation.circom"; 
+(epoch_key, state_tree_root, control) <== ProveReputation(STATE_TREE_DEPTH, EPOCH_KEY_NONCE_PER_EPOCH, SUM_FIELD_COUNT, FIELD_COUNT, REPL_NONCE_BITS)(
+  identity_secret,
+  state_tree_indexes,
+  state_tree_elements,
+  data,
+  prove_graffiti,
+  graffiti,
+  reveal_nonce,
+  attester_id,
+  epoch,
+  nonce,
+  min_rep,
+  max_rep,
+  prove_min_rep,
+  prove_max_rep,
+  prove_zero_rep,
+  sig_data
+);
+```
+
 :::info
 Control fields are used to encode many small values into a single field element. This reduces the number of public signals needed to operate a circuit.
 :::
@@ -190,3 +251,31 @@ Outputs:
 - `state_tree_leaf`
 - `epks[EPOCH_KEY_NONCE_PER_EPOCH]`
 
+Interface: 
+```js
+// pragma circom 2.1.0;
+// include "PATH/node_modules/@unirep/circuits/circuits/userStateTransition.circom"; 
+(history_tree_root, state_tree_leaf, epks) <== UserStateTransition(
+  STATE_TREE_DEPTH,
+  EPOCH_TREE_DEPTH,
+  HISTORY_TREE_DEPTH,
+  EPOCH_KEY_NONCE_PER_EPOCH,
+  FIELD_COUNT,
+  SUM_FIELD_COUNT,
+  REPL_NONCE_BITS
+)(
+  from_epoch,
+  to_epoch,
+  identity_secret,
+  state_tree_indexes,
+  state_tree_elements,
+  history_tree_indices,
+  history_tree_elements,
+  attester_id,
+  data,
+  new_data,
+  epoch_tree_root,
+  epoch_tree_elements,
+  epoch_tree_indices
+);
+```


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally in root directory and any changes were pushed
- [x] Lint (`yarn lint:fix`) was run locally in root directory and any changes were pushed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #541 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Semaphore v4
1. Variable names: 
    1. External Nullifier → Scope
    2. Siblings → Tree Siblings
    3. Path Indices → Tree Indices
2. Simplified identity: The two old identity secrets (`trapdoor` and `nullifier`) have been replaced by 1 secret only (`secret`). So `identity commitment = hash(identity secret)`, and `nullifier hash = hash(scope, identity secret)`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
