### PR TITLE
feat: add genesis block as configuration in synchronizer

### DIFF
--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -131,7 +131,7 @@ export class Synchronizer extends EventEmitter {
      * The genesis block of the provider environment
      * @dev Allow passing the genesis block as the starting block for querying events
      */
-    public genesisBlock: number = 0
+    private _genesisBlock: number = 0
 
     /**
      * @private
@@ -193,7 +193,7 @@ export class Synchronizer extends EventEmitter {
             provider
         )
         this._provider = provider
-        this.genesisBlock = genesisBlock ?? 0
+        this._genesisBlock = genesisBlock ?? 0
         this._settings = {
             stateTreeDepth: 0,
             epochTreeDepth: 0,
@@ -310,6 +310,13 @@ export class Synchronizer extends EventEmitter {
      */
     get settings() {
         return this._settings
+    }
+
+    /**
+     * Read the genesis block of the provider environment.
+     */
+    get genesisBlock() {
+        return this._genesisBlock
     }
 
     /**
@@ -434,7 +441,7 @@ export class Synchronizer extends EventEmitter {
         }
         const events = await this.unirepContract.queryFilter(
             filter,
-            this.genesisBlock
+            this._genesisBlock
         )
         if (events.length === 0) {
             throw new Error(

--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -128,8 +128,7 @@ export class Synchronizer extends EventEmitter {
      */
     public blockRate: number = 10000
     /**
-     * The genesis block of the provider environment
-     * @dev Allow passing the genesis block as the starting block for querying events
+     * Allow passing the genesis block as the starting block for querying events
      */
     private _genesisBlock: number = 0
 

--- a/packages/core/src/Synchronizer.ts
+++ b/packages/core/src/Synchronizer.ts
@@ -127,6 +127,11 @@ export class Synchronizer extends EventEmitter {
      * How many blocks the synchronizer will query on each poll. Default: `100000`
      */
     public blockRate: number = 10000
+    /**
+     * The genesis block of the provider environment
+     * @dev Allow passing the genesis block as the starting block for querying events
+     */
+    public genesisBlock: number = 0
 
     /**
      * @private
@@ -166,9 +171,10 @@ export class Synchronizer extends EventEmitter {
         attesterId?: bigint | bigint[]
         provider: ethers.providers.Provider
         unirepAddress: string
+        genesisBlock?: number
     }) {
         super()
-        const { db, unirepAddress, provider, attesterId } = config
+        const { db, unirepAddress, provider, attesterId, genesisBlock } = config
 
         if (Array.isArray(attesterId)) {
             // multiple attesters
@@ -187,6 +193,7 @@ export class Synchronizer extends EventEmitter {
             provider
         )
         this._provider = provider
+        this.genesisBlock = genesisBlock ?? 0
         this._settings = {
             stateTreeDepth: 0,
             epochTreeDepth: 0,
@@ -425,7 +432,10 @@ export class Synchronizer extends EventEmitter {
                 ),
             ])
         }
-        const events = await this.unirepContract.queryFilter(filter)
+        const events = await this.unirepContract.queryFilter(
+            filter,
+            this.genesisBlock
+        )
         if (events.length === 0) {
             throw new Error(
                 `@unirep/core:Synchronizer: failed to fetch genesis event`


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally in root directory and any changes were pushed
- [x] Lint (`yarn lint:fix`) was run locally in root directory and any changes were pushed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the current Synchronizer design, `_findStartBlock` will always start querying from block `0x0`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

In this pull request, we add a configuration variable `genesisBlock`. There are two benefits for the application that inherits this change. One is that by specifying the genesisBlock, they can shorten the setup time since the Synchronizer can now query from a closer block instead of block 0. The second benefit is that DevOps tools like Tenderly only support forking from the latest 1000 blocks at this moment. With this change, we can integrate Tenderly DevNet into the CICD deployment.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
